### PR TITLE
Fix inverted markdown link syntax in link README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ $ helm install my-release -f values.yaml springboard/typesense
 
 ### Typesense settings
 
-You can configure any typesense setting using the `envFrom` parameter like so. (Learn about envFrom)[https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container]
+You can configure any typesense setting using the `envFrom` parameter like so. [Learn about envFrom](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/#define-an-environment-variable-for-a-container)
 
 ```yaml
 envFrom:


### PR DESCRIPTION
Hey, thanks for taking the time to make this repo!

While reviewing the README, I seen an inverted markdown syntax link and have updated it with this PR.

Changed from `(Label)[URI]` => `[Label](URI)`.