### PR TITLE
fix: make liveness and readiness probes configurable

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,19 +44,9 @@ spec:
             - name: http
               containerPort: {{ .Values.applicationPort }}
           livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 60
-            timeoutSeconds: 5
-            failureThreshold: 6
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 5
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           {{- if .Values.resources }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,24 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
+## Container Liveness and Readiness Probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+##
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 60
+  timeoutSeconds: 5
+  failureThreshold: 6
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  timeoutSeconds: 3
+  periodSeconds: 5
+
 ## typesense conatiners' resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
 ##


### PR DESCRIPTION
I've ran into an issue while running Typesense with this helm chart. Sometimes Typesense can't start back up and clear it's write queue in time before the kubernetes liveness check fails and causes the pod to get restarted, this sends Typesense into a never ending crashloop and the only way I could work around this is by manually changing the liveness check on the deployment. 

This change allows users to configure liveness and readiness probes. The defaults are the same as they were before.